### PR TITLE
Add Crasher workflow

### DIFF
--- a/.github/workflows/run-crasher.yml
+++ b/.github/workflows/run-crasher.yml
@@ -32,10 +32,6 @@ jobs:
       # checkout crasher
       - name: Checkout Crasher
         uses: actions/checkout@v4
-      - name: Cache deps
-        uses: Swatinem/rust-cache@v2
-      - name: Build Crasher
-        run: cargo build
       # checkout qdrant dev
       - name: Checkout Qdrant
         uses: actions/checkout@v4
@@ -43,6 +39,15 @@ jobs:
           repository: qdrant/qdrant
           ref: dev
           path: ./qdrant
+      - name: Cache deps
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            /home/runner/work/crasher/crasher
+            /home/runner/work/crasher/crasher/qdrant
+      #          cache-directories: "/home/runner/work/crasher/crasher/qdrant"
+      - name: Build Crasher
+        run: cargo build
       - name: Build Qdrant
         working-directory: /home/runner/work/crasher/crasher/qdrant
         run: cargo build
@@ -56,9 +61,9 @@ jobs:
           fi
           ./qdrant/target/debug/qdrant --version
           ./crash-things.sh "/home/runner/work/crasher/crasher/qdrant/" "target/debug/qdrant" "0.3" "$crashing_time"
-          cat crasher_output.log
       - name: Upload logs in case of failure
         uses: actions/upload-artifact@v4
+        if: failure() || cancelled()
         with:
           name: crasher-logs
           retention-days: 2 # default max value

--- a/.github/workflows/run-crasher.yml
+++ b/.github/workflows/run-crasher.yml
@@ -5,6 +5,9 @@ on:
     branches: [ "ci/add-workflow", "master" ]
   pull_request:
     branches: [ "master" ]
+  schedule:
+    # every day at 12 CET
+    - cron: "0 14 * * *"
   workflow_dispatch:
     inputs:
       qdrant_version:

--- a/.github/workflows/run-crasher.yml
+++ b/.github/workflows/run-crasher.yml
@@ -2,10 +2,9 @@ name: Crash
 
 on:
   push:
-#    branches: [ "master" ]
-    branches: [ "ci/add-workflow" ]
-#  pull_request:
-#    branches: [ "master" ]
+    branches: [ "ci/add-workflow", "master" ]
+  pull_request:
+    branches: [ "master" ]
   workflow_dispatch:
     branches: [ "ci/add-workflow" ]
     inputs:
@@ -13,8 +12,8 @@ on:
         description: "Version of qdrant to checkout (tags/v1.6.1, <commit-id>, my-branch)"
         default: dev
       crashing_time:
-        description: "Duration in seconds"
-        default: 300
+        description: "Duration in seconds, default is 1200s (20 min) "
+        default: 1200
 
 env:
   CARGO_TERM_COLOR: always
@@ -32,12 +31,27 @@ jobs:
       # checkout crasher
       - name: Checkout Crasher
         uses: actions/checkout@v4
+      - name: Process inputs
+        id: default_inputs
+        run: |
+          qdrant_version="${{ inputs.qdrant_version }}"
+          if [ -z "$qdrant_version" ]; then
+            qdrant_version="dev"
+          fi
+          
+          crashing_time="${{ inputs.crashing_time }}"
+          if [ -z "$crashing_time" ]; then
+            crashing_time="1200"
+          fi          
+          
+          echo "qdrant_version=${qdrant_version}" >> $GITHUB_OUTPUT
+          echo "crashing_time=${crashing_time}" >> $GITHUB_OUTPUT
       # checkout qdrant dev
       - name: Checkout Qdrant
         uses: actions/checkout@v4
         with:
           repository: qdrant/qdrant
-          ref: dev
+          ref: ${{ steps.default_inputs.outputs.qdrant_version }}
           path: ./qdrant
       - name: Cache deps
         uses: Swatinem/rust-cache@v2
@@ -45,7 +59,6 @@ jobs:
           workspaces: |
             /home/runner/work/crasher/crasher
             /home/runner/work/crasher/crasher/qdrant
-      #          cache-directories: "/home/runner/work/crasher/crasher/qdrant"
       - name: Build Crasher
         run: cargo build
       - name: Build Qdrant
@@ -55,10 +68,8 @@ jobs:
         working-directory: /home/runner/work/crasher/crasher
         shell: bash
         run: |
-          crashing_time="${{ inputs.crashing_time }}"
-          if [ -z "$crashing_time" ]; then
-            crashing_time="300"
-          fi
+          crashing_time="${{ steps.default_inputs.outputs.crashing_time }}"
+          echo "$crashing_time"
           ./qdrant/target/debug/qdrant --version
           ./crash-things.sh "/home/runner/work/crasher/crasher/qdrant/" "target/debug/qdrant" "0.3" "$crashing_time"
       - name: Upload logs in case of failure
@@ -66,5 +77,5 @@ jobs:
         if: failure() || cancelled()
         with:
           name: crasher-logs
-          retention-days: 2 # default max value
+          retention-days: 90 # default max value
           path: crasher_output.log

--- a/.github/workflows/run-crasher.yml
+++ b/.github/workflows/run-crasher.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches: [ "master" ]
   workflow_dispatch:
-    branches: [ "ci/add-workflow" ]
     inputs:
       qdrant_version:
         description: "Version of qdrant to checkout (tags/v1.6.1, <commit-id>, my-branch)"
@@ -22,15 +21,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Install minimal stable
-        uses: dtolnay/rust-toolchain@stable
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      # checkout crasher
-      - name: Checkout Crasher
-        uses: actions/checkout@v4
       - name: Process inputs
         id: default_inputs
         run: |
@@ -46,6 +36,15 @@ jobs:
           
           echo "qdrant_version=${qdrant_version}" >> $GITHUB_OUTPUT
           echo "crashing_time=${crashing_time}" >> $GITHUB_OUTPUT
+      - name: Install minimal stable
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      # checkout crasher
+      - name: Checkout Crasher
+        uses: actions/checkout@v4
       # checkout qdrant dev
       - name: Checkout Qdrant
         uses: actions/checkout@v4
@@ -69,8 +68,6 @@ jobs:
         shell: bash
         run: |
           crashing_time="${{ steps.default_inputs.outputs.crashing_time }}"
-          echo "$crashing_time"
-          ./qdrant/target/debug/qdrant --version
           ./crash-things.sh "/home/runner/work/crasher/crasher/qdrant/" "target/debug/qdrant" "0.3" "$crashing_time"
       - name: Upload logs in case of failure
         uses: actions/upload-artifact@v4

--- a/.github/workflows/run-crasher.yml
+++ b/.github/workflows/run-crasher.yml
@@ -69,7 +69,7 @@ jobs:
         shell: bash
         run: |
           crashing_time="${{ steps.default_inputs.outputs.crashing_time }}"
-          ./crash-things.sh "/home/runner/work/crasher/crasher/qdrant/" "target/debug/qdrant" "0.3" "$crashing_time"
+          ./crash-things.sh "/home/runner/work/crasher/crasher/qdrant/" "target/debug/qdrant" "0.2" "$crashing_time"
       - name: Upload logs in case of failure
         uses: actions/upload-artifact@v4
         if: failure() || cancelled()

--- a/.github/workflows/run-crasher.yml
+++ b/.github/workflows/run-crasher.yml
@@ -3,8 +3,6 @@ name: Crash
 on:
   push:
     branches: [ "ci/add-workflow", "master" ]
-  pull_request:
-    branches: [ "master" ]
   schedule:
     # every day at 12 CET
     - cron: "0 14 * * *"

--- a/.github/workflows/run-crasher.yml
+++ b/.github/workflows/run-crasher.yml
@@ -1,0 +1,65 @@
+name: Crash
+
+on:
+  push:
+#    branches: [ "master" ]
+    branches: [ "ci/add-workflow" ]
+#  pull_request:
+#    branches: [ "master" ]
+  workflow_dispatch:
+    branches: [ "ci/add-workflow" ]
+    inputs:
+      qdrant_version:
+        description: "Version of qdrant to checkout (tags/v1.6.1, <commit-id>, my-branch)"
+        default: dev
+      crashing_time:
+        description: "Duration in seconds"
+        default: 300
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install minimal stable
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      # checkout crasher
+      - name: Checkout Crasher
+        uses: actions/checkout@v4
+      - name: Cache deps
+        uses: Swatinem/rust-cache@v2
+      - name: Build Crasher
+        run: cargo build
+      # checkout qdrant dev
+      - name: Checkout Qdrant
+        uses: actions/checkout@v4
+        with:
+          repository: qdrant/qdrant
+          ref: dev
+          path: ./qdrant
+      - name: Build Qdrant
+        working-directory: /home/runner/work/crasher/crasher/qdrant
+        run: cargo build
+      - name: Crash things
+        working-directory: /home/runner/work/crasher/crasher
+        shell: bash
+        run: |
+          crashing_time="${{ inputs.crashing_time }}"
+          if [ -z "$crashing_time" ]; then
+            crashing_time="300"
+          fi
+          ./qdrant/target/debug/qdrant --version
+          ./crash-things.sh "/home/runner/work/crasher/crasher/qdrant/" "target/debug/qdrant" "0.3" "$crashing_time"
+          cat crasher_output.log
+      - name: Upload logs in case of failure
+        uses: actions/upload-artifact@v4
+        with:
+          name: crasher-logs
+          retention-days: 2 # default max value
+          path: crasher_output.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .idea
 *.iml
+*.log

--- a/crash-things.sh
+++ b/crash-things.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -e
+
+QDRANT_DIR=${1:-"./qdrant/"}
+QDRANT_EXEC=${2:-"target/debug/qdrant"}
+CRASH_PROBABILITY=${3:-"0.3"}
+LOG_FILE="crasher_output.log"
+RUN_TIME=${4:-300}
+
+CRASHER_CMD="cargo run -r -- --working-dir $QDRANT_DIR --exec-path $QDRANT_EXEC --only-sparse --crash-probability $CRASH_PROBABILITY"
+echo "$CRASHER_CMD"
+$CRASHER_CMD > $LOG_FILE 2>&1 &
+pid=$!
+
+echo "The PID is $pid"
+
+function cleanup() {
+    kill -9 $pid 2>/dev/null
+}
+
+trap cleanup EXIT
+
+if ps -p $pid > /dev/null; then
+    echo "The process is running. Wait for $RUN_TIME seconds."
+    sleep $RUN_TIME
+
+    if ps -p $pid > /dev/null; then
+        echo "The process is still running. Stopping the process..."
+
+        kill $pid
+
+        echo "OK"
+    else
+        echo "The process has unexpectedly terminated on its own. Check the logs."
+        exit 1
+    fi
+else
+    echo "The process did not start correctly or has already terminated. Check the logs."
+    exit 2
+fi

--- a/crash-things.sh
+++ b/crash-things.sh
@@ -4,11 +4,11 @@ set -e
 
 QDRANT_DIR=${1:-"./qdrant/"}
 QDRANT_EXEC=${2:-"target/debug/qdrant"}
-CRASH_PROBABILITY=${3:-"0.3"}
+CRASH_PROBABILITY=${3:-"0.2"}
 LOG_FILE="crasher_output.log"
 RUN_TIME=${4:-300}
 
-CRASHER_CMD="cargo run -r -- --working-dir $QDRANT_DIR --exec-path $QDRANT_EXEC --only-sparse --crash-probability $CRASH_PROBABILITY"
+CRASHER_CMD="cargo run -r -- --working-dir $QDRANT_DIR --exec-path $QDRANT_EXEC --crash-probability $CRASH_PROBABILITY"
 echo "$CRASHER_CMD"
 $CRASHER_CMD > $LOG_FILE 2>&1 &
 pid=$!


### PR DESCRIPTION
Add a workflow to run Crasher cmd `cargo run -r -- --working-dir "working_dir" --exec-path "path_to_exec" --only-sparse --crash-probability 0.3` for 20 minutes. If after 20 minutes the command is still running the run is considered as a success, no output is stored. If after 20 minutes the command is not running then it's considered as a failure and output is stored as a GitHub artifact (retention period is 90 days).

Manual dispatch has 2 input params:
* qdrant_version (Version of qdrant to checkout (tags/v1.6.1, <commit-id>, my-branch), default is dev)
* crashing_time (Duration in seconds, default is 1200s (20 min))



