### PR TITLE
Add "missing payload" check to crasher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +256,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,6 +336,7 @@ name = "crasher"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "ctrlc",
  "env_logger",
@@ -771,6 +801,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,6 +965,15 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1879,6 +1941,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.86"
 thiserror = "1.0.61"
+chrono = "0.4"
 rand = "0.8.5"
 clap = { version = "4.5.8", features = ["derive"] }
 tokio = { version = "1.38.0", features = ["full"] }

--- a/crash-things.sh
+++ b/crash-things.sh
@@ -8,7 +8,7 @@ CRASH_PROBABILITY=${3:-"0.3"}
 LOG_FILE="crasher_output.log"
 RUN_TIME=${4:-300}
 
-CRASHER_CMD="cargo run -r -- --working-dir $QDRANT_DIR --exec-path $QDRANT_EXEC --crash-probability $CRASH_PROBABILITY"
+CRASHER_CMD="cargo run -r -- --working-dir $QDRANT_DIR --exec-path $QDRANT_EXEC --crash-probability $CRASH_PROBABILITY --missing-payload-check"
 echo "$CRASHER_CMD"
 $CRASHER_CMD > $LOG_FILE 2>&1 &
 pid=$!

--- a/src/args.rs
+++ b/src/args.rs
@@ -55,4 +55,7 @@ pub struct Args {
     /// Whether to perform extra consistency check
     #[arg(long, default_value_t = false)]
     pub consistency_check: bool,
+    /// Enable additional check that all points contain payload
+    #[arg(long)]
+    pub missing_payload_check: bool,
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -275,6 +275,7 @@ pub async fn insert_points_batch(
     points_count: usize,
     vec_dim: usize,
     payload_count: usize,
+    timestamp_payload: bool,
     only_sparse_vectors: bool,
     test_named_vectors: &TestNamedVectors,
     write_ordering: Option<WriteOrdering>,
@@ -335,11 +336,16 @@ pub async fn insert_points_batch(
 
             let vectors: Vectors = vectors_map.into();
 
-            points.push(PointStruct::new(
-                point_id,
-                vectors,
-                random_payload(Some(payload_count)),
-            ));
+            let mut payload = random_payload(Some(payload_count));
+
+            if timestamp_payload {
+                payload.insert(
+                    "timestamp",
+                    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+                );
+            }
+
+            points.push(PointStruct::new(point_id, vectors, payload));
         }
         if stopped.load(Ordering::Relaxed) {
             return Err(Cancelled);


### PR DESCRIPTION
Trying to catch that elusive bug on chaos-testing, when some points seem to miss payload after restart. 🥲