### PR TITLE
Add `--backup-working-dir` option

### DIFF
--- a/.github/workflows/run-crasher.yml
+++ b/.github/workflows/run-crasher.yml
@@ -33,12 +33,12 @@ jobs:
           if [ -z "$qdrant_version" ]; then
             qdrant_version="dev"
           fi
-          
+
           crashing_time="${{ inputs.crashing_time }}"
           if [ -z "$crashing_time" ]; then
             crashing_time="3600"
-          fi          
-          
+          fi
+
           echo "qdrant_version=${qdrant_version}" >> $GITHUB_OUTPUT
           echo "crashing_time=${crashing_time}" >> $GITHUB_OUTPUT
       - name: Install minimal stable
@@ -76,7 +76,7 @@ jobs:
           cp -r qdrant-src/config qdrant
 
           crashing_time="${{ steps.default_inputs.outputs.crashing_time }}"
-          bakup_working_dir="${{ inputs.backup_working_dir && qdrant-backup }}"
+          bakup_working_dir="${{ inputs.backup_working_dir && 'qdrant-backup' }}"
 
           ./crash-things.sh qdrant ../qdrant-src/target/debug/qdrant 0.3 "$crashing_time" "$backup_working_dir"
       - name: Upload logs on failure

--- a/.github/workflows/run-crasher.yml
+++ b/.github/workflows/run-crasher.yml
@@ -76,7 +76,7 @@ jobs:
           cp -r qdrant-src/config qdrant
 
           crashing_time="${{ steps.default_inputs.outputs.crashing_time }}"
-          bakup_working_dir="${{ inputs.backup_working_dir && 'qdrant-backup' }}"
+          backup_working_dir="${{ inputs.backup_working_dir && 'qdrant-backup' }}"
 
           ./crash-things.sh qdrant ../qdrant-src/target/debug/qdrant 0.3 "$crashing_time" "$backup_working_dir"
       - name: Upload logs on failure

--- a/.github/workflows/run-crasher.yml
+++ b/.github/workflows/run-crasher.yml
@@ -14,6 +14,10 @@ on:
       crashing_time:
         description: "Duration in seconds, default is 3600s (60 min) "
         default: 3600
+      backup_working_dir:
+        description: "Backup working dir before each Qdrant restart"
+        type: boolean
+        default: false
 
 env:
   CARGO_TERM_COLOR: always
@@ -52,24 +56,29 @@ jobs:
         with:
           repository: qdrant/qdrant
           ref: ${{ steps.default_inputs.outputs.qdrant_version }}
-          path: ./qdrant
+          path: ./qdrant-src
       - name: Cache deps
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
             /home/runner/work/crasher/crasher
-            /home/runner/work/crasher/crasher/qdrant
+            /home/runner/work/crasher/crasher/qdrant-src
       - name: Build Crasher (release)
-        run: cargo build -r
+        run: cargo build --release
       - name: Build Qdrant (debug)
-        working-directory: /home/runner/work/crasher/crasher/qdrant
+        working-directory: /home/runner/work/crasher/crasher/qdrant-src
         run: cargo build --features "service_debug data-consistency-check"
       - name: Crash things
         working-directory: /home/runner/work/crasher/crasher
         shell: bash
         run: |
+          mkdir qdrant
+          cp -r qdrant-src/config qdrant
+
           crashing_time="${{ steps.default_inputs.outputs.crashing_time }}"
-          ./crash-things.sh "/home/runner/work/crasher/crasher/qdrant/" "target/debug/qdrant" "0.3" "$crashing_time"
+          bakup_working_dir="${{ inputs.backup_working_dir && qdrant-backup }}"
+
+          ./crash-things.sh qdrant ../qdrant-src/target/debug/qdrant 0.3 "$crashing_time" "$backup_working_dir"
       - name: Upload logs on failure
         uses: actions/upload-artifact@v4
         if: failure() || cancelled()
@@ -77,6 +86,24 @@ jobs:
           name: crasher-logs
           retention-days: 90 # default max value
           path: crasher_output.log
+      - name: Archive Qdrant storage on failure
+        if: failure() || cancelled()
+        working-directory: /home/runner/work/crasher/crasher
+        shell: bash
+        run: |
+          if [[ -d qdrant-backup ]]
+          then
+            tar -caf qdrant.tar.gz qdrant qdrant-backup
+          else
+            tar -caf qdrant.tar.gz qdrant
+          fi
+      - name: Upload Qdrant storage on failure
+        uses: actions/upload-artifact@v4
+        if: failure() || cancelled()
+        with:
+          name: qdrant-data
+          retention-days: 10
+          path: qdrant.tar.gz
       - name: Send Notification
         if: failure() || cancelled()
         uses: slackapi/slack-github-action@v1.26.0

--- a/.github/workflows/run-crasher.yml
+++ b/.github/workflows/run-crasher.yml
@@ -86,24 +86,15 @@ jobs:
           name: crasher-logs
           retention-days: 90 # default max value
           path: crasher_output.log
-      - name: Archive Qdrant storage on failure
-        if: failure() || cancelled()
-        working-directory: /home/runner/work/crasher/crasher
-        shell: bash
-        run: |
-          if [[ -d qdrant-backup ]]
-          then
-            tar -caf qdrant.tar.gz qdrant qdrant-backup
-          else
-            tar -caf qdrant.tar.gz qdrant
-          fi
-      - name: Upload Qdrant storage on failure
+      - name: Upload Qdrant workdir on failure
         uses: actions/upload-artifact@v4
         if: failure() || cancelled()
         with:
-          name: qdrant-data
+          name: qdrant-workdir
           retention-days: 10
-          path: qdrant.tar.gz
+          path: |
+            qdrant/
+            qdrant-backup/
       - name: Send Notification
         if: failure() || cancelled()
         uses: slackapi/slack-github-action@v1.26.0

--- a/.github/workflows/run-crasher.yml
+++ b/.github/workflows/run-crasher.yml
@@ -31,16 +31,16 @@ jobs:
         run: |
           qdrant_version="${{ inputs.qdrant_version }}"
           if [ -z "$qdrant_version" ]; then
-            qdrant_version="dev"
+            qdrant_version=dev
           fi
 
           crashing_time="${{ inputs.crashing_time }}"
           if [ -z "$crashing_time" ]; then
-            crashing_time="3600"
+            crashing_time=3600
           fi
 
-          echo "qdrant_version=${qdrant_version}" >> $GITHUB_OUTPUT
-          echo "crashing_time=${crashing_time}" >> $GITHUB_OUTPUT
+          echo "qdrant_version=$qdrant_version" >> $GITHUB_OUTPUT
+          echo "crashing_time=$crashing_time" >> $GITHUB_OUTPUT
       - name: Install minimal stable
         uses: dtolnay/rust-toolchain@stable
       - name: Install Protoc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,11 +340,13 @@ dependencies = [
  "clap",
  "ctrlc",
  "env_logger",
+ "futures",
  "log",
  "qdrant-client",
  "rand",
  "thiserror",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -493,12 +495,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -542,6 +559,7 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,9 @@ thiserror = "1.0.61"
 chrono = "0.4"
 rand = "0.8.5"
 clap = { version = "4.5.8", features = ["derive"] }
+futures = { version = "0.3", default-features = false, features = ["async-await", "std"] }
 tokio = { version = "1.38.0", features = ["full"] }
+tokio-stream = { version = "0.1", default-features = false, features = ["fs"] }
 qdrant-client = { git = "https://github.com/qdrant/rust-client.git", branch = "dev" }
 ctrlc = "3.4.4"
 log = "0.4.22"

--- a/crash-things.sh
+++ b/crash-things.sh
@@ -14,7 +14,7 @@ CRASHER_CMD=(
     cargo run --release
     --
     --working-dir "$QDRANT_DIR"
-    ${QDRANT_BACKUP_DIR:+--backup-working-dir} "${QDRANT_BACKUP_DIR-}"
+    ${QDRANT_BACKUP_DIR:+--backup-working-dir "$QDRANT_BACKUP_DIR"}
     --exec-path "$QDRANT_EXEC"
     --crash-probability "$CRASH_PROBABILITY"
     --missing-payload-check

--- a/crash-things.sh
+++ b/crash-things.sh
@@ -27,10 +27,13 @@ pid=$!
 echo "The PID is $pid"
 
 function cleanup() {
-    kill -9 $pid 2>/dev/null
+    kill -KILL $pid 2>/dev/null
 }
 
-trap cleanup EXIT INT ERR
+trap cleanup EXIT
+
+trap 'exit $?' ERR
+trap exit INT
 
 if ps -p $pid >/dev/null
 then

--- a/crash-things.sh
+++ b/crash-things.sh
@@ -2,13 +2,13 @@
 
 set -e
 
-QDRANT_DIR="${1:-./qdrant/}"
-QDRANT_EXEC="${2:-target/debug/qdrant}"
-CRASH_PROBABILITY="${3:-0.3}"
-RUN_TIME="${4:-300}"
-QDRANT_BACKUP_DIR="${5:-}"
+QDRANT_DIR=${1:-./qdrant/}
+QDRANT_EXEC=${2:-target/debug/qdrant}
+CRASH_PROBABILITY=${3:-0.3}
+RUN_TIME=${4:-300}
+QDRANT_BACKUP_DIR=${5:-}
 
-LOG_FILE="crasher_output.log"
+LOG_FILE=crasher_output.log
 
 CRASHER_CMD=(
     cargo run --release

--- a/crash-things.sh
+++ b/crash-things.sh
@@ -1,16 +1,27 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
-QDRANT_DIR=${1:-"./qdrant/"}
-QDRANT_EXEC=${2:-"target/debug/qdrant"}
-CRASH_PROBABILITY=${3:-"0.3"}
-LOG_FILE="crasher_output.log"
-RUN_TIME=${4:-300}
+QDRANT_DIR="${1:-./qdrant/}"
+QDRANT_EXEC="${2:-target/debug/qdrant}"
+CRASH_PROBABILITY="${3:-0.3}"
+RUN_TIME="${4:-300}"
+QDRANT_BACKUP_DIR="${5:-}"
 
-CRASHER_CMD="cargo run -r -- --working-dir $QDRANT_DIR --exec-path $QDRANT_EXEC --crash-probability $CRASH_PROBABILITY --missing-payload-check"
-echo "$CRASHER_CMD"
-$CRASHER_CMD > $LOG_FILE 2>&1 &
+LOG_FILE="crasher_output.log"
+
+CRASHER_CMD=(
+    cargo run --release
+    --
+    --working-dir "$QDRANT_DIR"
+    ${QDRANT_BACKUP_DIR:+--backup-working-dir} "${QDRANT_BACKUP_DIR-}"
+    --exec-path "$QDRANT_EXEC"
+    --crash-probability "$CRASH_PROBABILITY"
+    --missing-payload-check
+)
+
+echo "${CRASHER_CMD[*]}"
+"${CRASHER_CMD[@]}" &>"$LOG_FILE" &
 pid=$!
 
 echo "The PID is $pid"
@@ -19,17 +30,17 @@ function cleanup() {
     kill -9 $pid 2>/dev/null
 }
 
-trap cleanup EXIT
+trap cleanup EXIT INT ERR
 
-if ps -p $pid > /dev/null; then
-    echo "The process is running. Wait for $RUN_TIME seconds."
-    sleep $RUN_TIME
+if ps -p $pid >/dev/null
+then
+    echo "The process is running. Waiting for $RUN_TIME seconds..."
+    sleep "$RUN_TIME"
 
-    if ps -p $pid > /dev/null; then
+    if ps -p $pid >/dev/null
+    then
         echo "The process is still running. Stopping the process..."
-
         kill $pid
-
         echo "OK"
     else
         echo "The process has unexpectedly terminated on its own. Check the logs."

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,8 @@ Usage: crasher [OPTIONS] --working-dir <WORKING_DIR> --exec-path <EXEC_PATH>
 Options:
       --working-dir <WORKING_DIR>
           Working directory for Qdrant data
+      --backup-working-dir <BACKUP_WORKING_DIR>
+          Backup working directory between Qdrant restarts (useful to debug storage recovery issues)
       --exec-path <EXEC_PATH>
           Path to executable binary relative to `working_dir`
       --crash-probability <CRASH_PROBABILITY>
@@ -46,7 +48,7 @@ Options:
       --only-sparse
           Whether to only upsert sparse vectors
       --duplication-factor <DUPLICATION_FACTOR>
-          Duplication factor for generating additional named vectors [default: 3]
+          Duplication factor for generating additional named vectors [default: 2]
       --consistency-check
           Whether to perform extra consistency check
       --missing-payload-check

--- a/src/args.rs
+++ b/src/args.rs
@@ -7,6 +7,9 @@ pub struct Args {
     /// Working directory for Qdrant data
     #[arg(long)]
     pub working_dir: String,
+    /// Backup working directory between Qdrant restarts (useful to debug storage recovery issues)
+    #[arg(long)]
+    pub backup_working_dir: Option<String>,
     /// Path to executable binary relative to `working_dir`
     #[arg(long)]
     pub exec_path: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod client;
 mod crasher_error;
 mod generators;
 mod process;
+mod util;
 mod workload;
 
 use crate::args::Args;
@@ -39,7 +40,7 @@ async fn main() {
     let crash_probability = args.crash_probability;
     let sleep_duration_between_crash_sec = args.sleep_duration_between_crash_sec;
 
-    match ProcessManager::new(&args.working_dir, &args.exec_path) {
+    match ProcessManager::from_args(&args) {
         Err(e) => {
             log::error!("Failed to start Qdrant: {}", e);
         }

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,10 +1,15 @@
+use crate::args::Args;
 use crate::client::wait_server_ready;
+use crate::util;
+use anyhow::Context as _;
 use qdrant_client::Qdrant;
 use rand::Rng;
+use std::io;
 use std::process::exit;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::fs;
 use tokio::process::{Child, Command};
 use tokio::time::sleep;
 
@@ -19,23 +24,61 @@ pub fn start_process(working_dir_path: &str, exec_path: &str) -> tokio::io::Resu
 
 pub struct ProcessManager {
     pub working_dir: String,
+    pub backup_working_dir: Option<String>,
     pub binary_path: String,
     pub child_process: Child,
 }
 
 impl ProcessManager {
-    pub fn new(working_dir: &str, binary_path: &str) -> tokio::io::Result<Self> {
+    pub fn from_args(args: &Args) -> io::Result<Self> {
+        let mut manager = Self::new(&args.working_dir, &args.exec_path)?;
+
+        if let Some(backup_working_dir) = &args.backup_working_dir {
+            manager.with_backup_working_dir(backup_working_dir);
+        }
+
+        Ok(manager)
+    }
+
+    pub fn new(working_dir: &str, binary_path: &str) -> io::Result<Self> {
         let child = start_process(working_dir, binary_path)?;
+
         Ok(Self {
             working_dir: working_dir.to_string(),
+            backup_working_dir: None,
             binary_path: binary_path.to_string(),
             child_process: child,
         })
     }
 
+    pub fn with_backup_working_dir(&mut self, backup_working_dir: &str) -> &mut Self {
+        self.backup_working_dir = Some(backup_working_dir.into());
+        self
+    }
+
     // Doc says: This is equivalent to sending a SIGKILL on unix platforms.
     pub async fn kill_process(&mut self) {
         self.child_process.kill().await.unwrap();
+    }
+
+    pub async fn backup_working_dir(&self) -> anyhow::Result<()> {
+        let Some(backup) = &self.backup_working_dir else {
+            return Ok(());
+        };
+
+        let backup_exists = fs::try_exists(backup)
+            .await
+            .with_context(|| format!("failed to query if backup working dir {backup} exists"))?;
+
+        if backup_exists {
+            fs::remove_dir_all(backup)
+                .await
+                .with_context(|| format!("failed to remove backup working dir {backup}"))?;
+        }
+
+        util::copy_dir(&self.working_dir, backup).await?;
+
+        Ok(())
     }
 
     pub async fn chaos(
@@ -57,11 +100,24 @@ impl ProcessManager {
             if drawn {
                 log::info!("** Restarting qdrant **");
                 self.kill_process().await;
+
+                if let Err(err) = self.backup_working_dir().await {
+                    log::error!(
+                        "Failed to backup working dir {} to {}: {err}",
+                        self.working_dir,
+                        self.backup_working_dir
+                            .as_ref()
+                            .expect("backup working dir"),
+                    );
+                }
+
                 self.child_process = start_process(&self.working_dir, &self.binary_path).unwrap();
+
                 if let Err(e) = wait_server_ready(client, stopped.clone()).await {
                     log::error!("Failed to wait for qdrant to be ready: {}", e);
                     exit(1);
                 }
+
                 log::info!("Qdrant is ready!");
             }
             // wait a bit before next chaos

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,64 @@
+use anyhow::Context as _;
+use futures::{future::BoxFuture, FutureExt as _, TryStreamExt as _};
+use std::path::PathBuf;
+use tokio::fs;
+
+pub fn copy_dir(
+    src: impl Into<PathBuf>,
+    dst: impl Into<PathBuf>,
+) -> BoxFuture<'static, anyhow::Result<()>> {
+    copy_dir_impl(src.into(), dst.into()).boxed()
+}
+
+async fn copy_dir_impl(src: PathBuf, dst: PathBuf) -> anyhow::Result<()> {
+    let read_dir = fs::read_dir(&src)
+        .await
+        .with_context(|| format!("failed to read directory {}", src.display()))?;
+
+    let dst_exists = fs::try_exists(&dst)
+        .await
+        .with_context(|| format!("failed to query if {} directory exists", dst.display()))?;
+
+    if dst_exists {
+        return Err(anyhow::format_err!(
+            "{} directory already exists",
+            dst.display()
+        ));
+    }
+
+    fs::create_dir_all(&dst)
+        .await
+        .with_context(|| format!("failed to create directory {}", dst.display()))?;
+
+    let mut entries = tokio_stream::wrappers::ReadDirStream::new(read_dir).map_err(|err| {
+        anyhow::Error::new(err).context(format!(
+            "failed to read next entry in {} directory",
+            src.display(),
+        ))
+    });
+
+    while let Some(entry) = entries.try_next().await? {
+        let entry_type = entry
+            .file_type()
+            .await
+            .with_context(|| format!("failed to read {} entry type", entry.path().display()))?;
+
+        let dst = dst.join(entry.file_name());
+
+        if entry_type.is_dir() {
+            copy_dir(entry.path(), dst).await?;
+        } else {
+            let entry_path = entry.path();
+
+            fs::copy(&entry_path, &dst).await.with_context(|| {
+                format!(
+                    "failed to copy {} file to {}",
+                    entry_path.display(),
+                    dst.display()
+                )
+            })?;
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Add an option to backup working dir before each restart. One of the data consistency bugs we fixed in Qdrant earlier, actually happened during data recovery on startup, so this option should help catch similar bugs.
