### PR TITLE
Fix `crash-things.sh` return error status on successful runs

### DIFF
--- a/crash-things.sh
+++ b/crash-things.sh
@@ -32,7 +32,10 @@ pid=$!
 echo "The PID is $pid"
 
 function cleanup() {
-    ps -p $pid >/dev/null && kill -KILL $pid
+    if ps -p $pid >/dev/null
+    then
+        kill -KILL $pid
+    fi
 }
 
 trap cleanup EXIT


### PR DESCRIPTION
It was the `cleanup` trap. 🙄
Tested locally, should be good to merge. 🤞