### PR TITLE
Rotate *multiple* backup working dirs

### DIFF
--- a/crash-things.sh
+++ b/crash-things.sh
@@ -6,7 +6,7 @@ QDRANT_DIR=${1:-./qdrant/}
 QDRANT_EXEC=${2:-target/debug/qdrant}
 CRASH_PROBABILITY=${3:-0.3}
 RUN_TIME=${4:-300}
-QDRANT_BACKUP_DIR=${5:-}
+QDRANT_BACKUP_DIRS=( "${@:5}" )
 
 CRASHER_LOG=crasher.log
 QDRANT_LOG=../qdrant.log
@@ -15,7 +15,7 @@ CRASHER_CMD=(
     cargo run --release
     --
     --working-dir "$QDRANT_DIR"
-    ${QDRANT_BACKUP_DIR:+--backup-working-dir "$QDRANT_BACKUP_DIR"}
+    ${QDRANT_BACKUP_DIRS[@]/#/--backup-working-dir } # this does not handle spaces 😬
     --exec-path "$QDRANT_EXEC"
     --crash-probability "$CRASH_PROBABILITY"
     --missing-payload-check

--- a/src/args.rs
+++ b/src/args.rs
@@ -9,7 +9,7 @@ pub struct Args {
     pub working_dir: String,
     /// Backup working directory between Qdrant restarts (useful to debug storage recovery issues)
     #[arg(long)]
-    pub backup_working_dir: Option<String>,
+    pub backup_working_dir: Vec<String>,
     /// Path to executable binary relative to `working_dir`
     #[arg(long)]
     pub exec_path: String,


### PR DESCRIPTION
The missing payload bug has a curios pattern, that it's *always* detected at the *second* restart after point was deleted. Instead of banging my head against the code and logs, I just plan to back up storage over 2-3 restarts and then debug this BS in the debugger. 😤