### PR TITLE
Render errors including list of causes

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -41,13 +41,13 @@ pub async fn wait_server_ready(
         let healthcheck = client.health_check().await;
         match healthcheck {
             Ok(_) => break,
-            Err(e) => {
+            Err(err) => {
                 if start.elapsed().as_secs_f64() > 60.0 {
                     return Err(CrasherError::Invariant(
                         "Server did not start in time, /readyz not ready".to_string(),
                     ));
                 } else {
-                    log::debug!("Healthcheck failed: {}", e)
+                    log::debug!("Healthcheck failed: {err:#}")
                 }
             }
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -47,7 +47,7 @@ pub async fn wait_server_ready(
                         "Server did not start in time, /readyz not ready".to_string(),
                     ));
                 } else {
-                    log::debug!("Healthcheck failed: {err:#}")
+                    log::debug!("Healthcheck failed: {err:?}")
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,9 +51,10 @@ async fn main() {
                 Some(child_process_id) => {
                     log::info!("Child qdrant process id {:?}", child_process_id);
                     log::info!("Waiting for qdrant to be ready...");
-                    if let Err(e) = wait_server_ready(&client.clone(), stopped.clone(), false).await
+                    if let Err(err) =
+                        wait_server_ready(&client.clone(), stopped.clone(), false).await
                     {
-                        log::error!("Failed to wait for qdrant to be ready: {}", e);
+                        log::error!("Failed to wait for qdrant to be ready: {err:#}");
                         exit(1)
                     }
                     log::info!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,13 +43,13 @@ async fn main() {
     let sleep_duration_between_crash_sec = args.sleep_duration_between_crash_sec;
 
     match ProcessManager::from_args(&args) {
-        Err(e) => {
-            log::error!("Failed to start Qdrant: {}", e);
+        Err(err) => {
+            log::error!("Failed to start Qdrant: {err}");
         }
         Ok(mut process_manager) => {
             match process_manager.child_process.id() {
                 Some(child_process_id) => {
-                    log::info!("Child qdrant process id {:?}", child_process_id);
+                    log::info!("Child qdrant process id {child_process_id:?}");
                     log::info!("Waiting for qdrant to be ready...");
                     if let Err(err) =
                         wait_server_ready(&client.clone(), stopped.clone(), false).await
@@ -59,7 +59,7 @@ async fn main() {
                     }
                     log::info!(
                         "Qdrant is ready! Crashing it with a probability of {}%",
-                        crash_probability * 100.0
+                        crash_probability * 100.0,
                     );
 
                     let collection_name = COLLECTION_NAME;

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ async fn main() {
                     if let Err(err) =
                         wait_server_ready(&client.clone(), stopped.clone(), false).await
                     {
-                        log::error!("Failed to wait for qdrant to be ready: {err:#}");
+                        log::error!("Failed to wait for qdrant to be ready: {err:?}");
                         exit(1)
                     }
                     log::info!(

--- a/src/process.rs
+++ b/src/process.rs
@@ -104,7 +104,7 @@ impl ProcessManager {
 
                 if let Err(err) = self.backup_working_dir().await {
                     log::error!(
-                        "Failed to backup working dir {} to {}: {err:#}",
+                        "Failed to backup working dir {} to {}: {err:?}",
                         self.working_dir,
                         self.backup_dirs.front().expect("backup dir"),
                     );
@@ -113,7 +113,7 @@ impl ProcessManager {
                 self.child_process = start_process(&self.working_dir, &self.binary_path).unwrap();
 
                 if let Err(err) = wait_server_ready(client, stopped.clone(), true).await {
-                    log::error!("Failed to wait for qdrant to be ready: {err:#}");
+                    log::error!("Failed to wait for qdrant to be ready: {err:?}");
                     exit(1);
                 }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -104,7 +104,7 @@ impl ProcessManager {
 
                 if let Err(err) = self.backup_working_dir().await {
                     log::error!(
-                        "Failed to backup working dir {} to {}: {err}",
+                        "Failed to backup working dir {} to {}: {err:#}",
                         self.working_dir,
                         self.backup_dirs.front().expect("backup dir"),
                     );
@@ -112,8 +112,8 @@ impl ProcessManager {
 
                 self.child_process = start_process(&self.working_dir, &self.binary_path).unwrap();
 
-                if let Err(e) = wait_server_ready(client, stopped.clone(), true).await {
-                    log::error!("Failed to wait for qdrant to be ready: {}", e);
+                if let Err(err) = wait_server_ready(client, stopped.clone(), true).await {
+                    log::error!("Failed to wait for qdrant to be ready: {err:#}");
                     exit(1);
                 }
 

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -87,13 +87,13 @@ impl Workload {
                     // turn client error into hard error if it is a server error (a bit hacky)
                     let debug_error = format!("{:?}", error);
                     if debug_error.contains("Service internal error") {
-                        log::error!("Workload run failed due to a server error!\n{error:#}");
+                        log::error!("Workload run failed due to a server error!\n{error:?}");
                         // send stop signal to the main thread
                         self.stopped.store(true, Ordering::Relaxed);
                         break;
                     } else {
                         log::warn!(
-                            "Workload run failed due to client error - resuming soon\n{error:#}"
+                            "Workload run failed due to client error - resuming soon\n{error:?}"
                         );
                         // no need to hammer the server while it restarts
                         sleep(std::time::Duration::from_secs(3)).await;

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -77,7 +77,7 @@ impl Workload {
                     break;
                 }
                 Err(Invariant(msg)) => {
-                    log::error!("Workload run failed with violation!\n{}", msg);
+                    log::error!("Workload run failed with violation!\n{msg}");
                     // send stop signal to the main thread
                     self.stopped.store(true, Ordering::Relaxed);
                     log::error!("Stopping the workload...");
@@ -220,7 +220,7 @@ impl Workload {
             }
 
             let collection_info = get_collection_info(client, &self.collection_name).await?;
-            log::info!("Collection info: {:#?}", collection_info);
+            log::info!("Collection info: {collection_info:#?}");
         }
 
         let current_count = get_points_count(client, &self.collection_name).await?;
@@ -228,7 +228,7 @@ impl Workload {
             if args.consistency_check {
                 // can be disabled if qdrant is running internal data consistency check on the server side
                 // `cargo run --features data-consistency-check`
-                log::info!("Run: pre vector data consistency check ({})", current_count);
+                log::info!("Run: pre vector data consistency check ({current_count})");
                 self.vector_data_consistency_check(client, current_count)
                     .await?;
             }
@@ -238,7 +238,7 @@ impl Workload {
                 self.missing_payload_check(client).await?;
             }
 
-            log::info!("Run: delete existing points ({})", current_count);
+            log::info!("Run: delete existing points ({current_count})");
             delete_points(client, &self.collection_name, current_count).await?;
         }
 

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -87,14 +87,13 @@ impl Workload {
                     // turn client error into hard error if it is a server error (a bit hacky)
                     let debug_error = format!("{:?}", error);
                     if debug_error.contains("Service internal error") {
-                        log::error!("Workload run failed due to a server error!\n{}", error);
+                        log::error!("Workload run failed due to a server error!\n{error:#}");
                         // send stop signal to the main thread
                         self.stopped.store(true, Ordering::Relaxed);
                         break;
                     } else {
                         log::warn!(
-                            "Workload run failed due to client error - resuming soon\n{}",
-                            error
+                            "Workload run failed due to client error - resuming soon\n{error:#}"
                         );
                         // no need to hammer the server while it restarts
                         sleep(std::time::Duration::from_secs(3)).await;


### PR DESCRIPTION
Errors currently reported are a bit meaningless because it only renders the outmost error, hiding the rest of the chain.

This changes our formatting to also include the rest of the chain, helping us understand the errors better.

For example, this is meaningless:

```
[2025-02-06T09:42:16.329Z ERROR crasher::workload] Workload run failed due to a server error!
    Failed to run points count for workload-crasher
```

Instead we now get something like:

```
[2025-02-06T10:01:06.733Z WARN  crasher::workload] Workload run failed due to client error - resuming soon
    Failed to insert 32 points (batch 21/157) into workload-crasher

    Caused by:
        Error in the response: Internal error Failed to connect to http://localhost:6334/: tonic::transport::Error(Transport, ConnectError(ConnectError("tcp connect error", Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })))
```

Documentation: https://docs.rs/anyhow/latest/anyhow/struct.Error.html#display-representations