### PR TITLE
Use wait=true in upsert requests

### DIFF
--- a/crash-things.sh
+++ b/crash-things.sh
@@ -19,6 +19,7 @@ CRASHER_CMD=(
     --exec-path "$QDRANT_EXEC"
     --crash-probability "$CRASH_PROBABILITY"
     --missing-payload-check
+    --wait
 )
 
 echo "${CRASHER_CMD[*]}"

--- a/src/args.rs
+++ b/src/args.rs
@@ -28,6 +28,9 @@ pub struct Args {
     /// Dimension of generated vectors
     #[arg(long, default_value_t = 1024)]
     pub vector_dimension: usize,
+    /// Always use wait=true on upsert requests.
+    #[arg(long)]
+    pub wait: bool,
     /// Configure the flush interval for collections
     #[arg(long, default_value_t = 5)]
     pub flush_interval_sec: usize,

--- a/src/client.rs
+++ b/src/client.rs
@@ -277,6 +277,7 @@ pub async fn insert_points_batch(
     collection_name: &str,
     points_count: usize,
     vec_dim: usize,
+    always_wait: bool,
     payload_count: usize,
     timestamp_payload: bool,
     only_sparse_vectors: bool,
@@ -303,7 +304,7 @@ pub async fn insert_points_batch(
         let (wait, batch_size) = if batch_id == num_batches - 1 {
             (true, last_batch_size)
         } else {
-            (false, batch_size)
+            (always_wait, batch_size)
         };
         let mut points = Vec::with_capacity(batch_size);
         let batch_base_id = batch_id as u64 * max_batch_size as u64;

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -249,6 +249,7 @@ impl Workload {
             &self.collection_name,
             self.points_count,
             self.vec_dim,
+            args.wait,
             0,                          // no payload at first
             args.missing_payload_check, // add timestamp payload for the missing payload check
             args.only_sparse,


### PR DESCRIPTION
Add a `--wait` flag to always use wait=true in upsert requests. This PR also adds the flag by default in `crash-things.sh`.

Using wait=false on may batches might be causing corrupted points. In this case, the WAL is not flushed on each operation and a crash might persist partially applied point data.

I suggest to give this a try for a while. If it doesn't make a difference, we can remove the default `--wait`.