### PR TITLE
Fix validation for unconfirmed points

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -383,6 +383,13 @@ pub async fn insert_points_batch(
             return Err(Cancelled);
         }
 
+        let inserting_points: Vec<_> = points.iter().map(|p| match p.id.as_ref().unwrap().point_id_options.as_ref().unwrap() {
+            PointIdOptions::Num(id) => *id,
+            PointIdOptions::Uuid(_) => unreachable!("UUIDs are not supported"),
+        }).collect::<Vec<_>>();
+
+        log::info!("Inserting points: {inserting_points:?}");
+
         let _resp = client
             .upsert_points(
                 UpsertPointsBuilder::new(collection_name, points)

--- a/src/client.rs
+++ b/src/client.rs
@@ -479,10 +479,7 @@ pub async fn retrieve_points(
 }
 
 /// delete points (blocking)
-pub async fn delete_points(
-    client: &Qdrant,
-    collection_name: &str,
-) -> Result<(), CrasherError> {
+pub async fn delete_points(client: &Qdrant, collection_name: &str) -> Result<(), CrasherError> {
     let points_selector = Filter::must([]);
 
     // delete all points

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -292,7 +292,7 @@ impl Workload {
             self.data_consistency_check(client, checkable_points)
                 .await?;
 
-            log::info!("Run: delete existing points (all points byt filter)");
+            log::info!("Run: delete existing points (all points by filter)");
             delete_points(client, &self.collection_name).await?;
             self.reset_max_confirmed_point_id()
         }

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -7,7 +7,7 @@ use qdrant_client::qdrant::{
 };
 use rand::Rng;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
@@ -40,6 +40,9 @@ pub struct Workload {
     stopped: Arc<AtomicBool>,
     crash_lock: Arc<tokio::sync::Mutex<()>>, // take lock to prevent crash
     rng_seed: u64,
+    // Largest point id written and confirmed by Qdrant
+    // Confirmation means, that API responded with `Completed` status for upsert request
+    max_confirmed_point_id: Arc<AtomicU64>,
 }
 
 impl Workload {
@@ -67,7 +70,21 @@ impl Workload {
             stopped,
             crash_lock,
             rng_seed,
+            max_confirmed_point_id: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    fn reset_max_confirmed_point_id(&self) {
+        self.max_confirmed_point_id.store(0, Ordering::Relaxed);
+    }
+
+    fn get_max_confirmed_point_id(&self) -> u64 {
+        self.max_confirmed_point_id.load(Ordering::Relaxed)
+    }
+
+    fn set_max_confirmed_point_id(&self, point_id: u64) {
+        self.max_confirmed_point_id
+            .store(point_id, Ordering::Relaxed);
     }
 }
 
@@ -133,6 +150,8 @@ impl Workload {
         log::info!("Starting workload...");
         // create and populate collection if it does not exist
         if !client.collection_exists(&self.collection_name).await? {
+            self.reset_max_confirmed_point_id();
+
             log::info!("Creating workload collection");
             create_collection(
                 client,
@@ -263,12 +282,18 @@ impl Workload {
 
         // Validate and clean up existing data
         let current_count = get_exact_points_count(client, &self.collection_name).await?;
+        let confirmed_point_id = self.get_max_confirmed_point_id();
+        let checkable_points = std::cmp::min(current_count as u64, confirmed_point_id) as usize;
         if current_count != 0 {
-            log::info!("Run: previous data consistency check ({current_count} points)");
-            self.data_consistency_check(client, current_count).await?;
+            log::info!(
+                "Run: previous data consistency check ({confirmed_point_id} / {current_count} points)"
+            );
+            self.data_consistency_check(client, checkable_points)
+                .await?;
 
-            log::info!("Run: delete existing points ({current_count} points)");
-            delete_points(client, &self.collection_name, current_count).await?;
+            log::info!("Run: delete existing points (all points byt filter)");
+            delete_points(client, &self.collection_name).await?;
+            self.reset_max_confirmed_point_id()
         }
 
         // Validate existing collection snapshots
@@ -304,7 +329,8 @@ impl Workload {
                 );
                 self.data_consistency_check(client, restored_count).await?;
 
-                delete_points(client, &self.collection_name, restored_count).await?;
+                delete_points(client, &self.collection_name).await?;
+                self.reset_max_confirmed_point_id()
             }
             log::info!("All snapshots validated and deleted!");
         }
@@ -325,6 +351,7 @@ impl Workload {
             None,
             self.stopped.clone(),
             rng,
+            |inserted_id| self.set_max_confirmed_point_id(inserted_id),
         )
         .await?;
 


### PR DESCRIPTION
Current point validation is built on assumption, that if we insert IDs sequentially, they are also applied sequentially.
Therefore, all the logic in the points validations is based on reading point count and checking that those points are all present.

While this assumption is correct for single shard, for multiple shards it is not, as each shard have individual WAL.
Consider folloing scenario:

- we write batch of 10 points into 3 shards.
- batch it splitted:
  - [2, 3, 8] - shard 0
  - [1, 4, 5, 9] - shard 1
  - [0, 6, 7] - shard 2

Update operation only responds if all shards confirmed the update, but it might be, that the shard 1 writes into WAL first, while shards 0 and 2 are not. At this point, if we restart service, written point IDs will not be sequential, however it is also not a bug of a service, as API never confirmed points.

This API tracks max point ID which was actually confirmed by insert operation and only allows validation against this ID.
