### PR TITLE
ci: Pin all gh actions to commit SHAs

### DIFF
--- a/.github/workflows/run-crasher.yml
+++ b/.github/workflows/run-crasher.yml
@@ -56,9 +56,9 @@ jobs:
           echo "crash_probability=$crash_probability" >> $GITHUB_OUTPUT
           echo "points_count=$points_count" >> $GITHUB_OUTPUT
       - name: Install minimal stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - name: Install mold
-        uses: rui314/setup-mold@v1
+        uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - name: Enable mold on Linux
         run: |
           if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
@@ -69,21 +69,21 @@ jobs:
           fi
         shell: bash
       - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       # checkout crasher
       - name: Checkout Crasher
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       # checkout qdrant dev
       - name: Checkout Qdrant
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: qdrant/qdrant
           ref: ${{ steps.default_inputs.outputs.qdrant_version }}
           path: ./qdrant-src
       - name: Cache deps
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: |
             /home/runner/work/crasher/crasher
@@ -109,7 +109,7 @@ jobs:
 
           ./crash-things.sh qdrant ../qdrant-src/target/debug/qdrant "$crash_probability" "$crashing_time" "$points_count" "$backup_storage_dir"
       - name: Upload logs on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure() || cancelled()
         with:
           name: logs
@@ -118,7 +118,7 @@ jobs:
             crasher.log
             qdrant.log
       - name: Upload Qdrant workdir on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure() || cancelled()
         with:
           name: qdrant-workdir
@@ -127,7 +127,7 @@ jobs:
             qdrant/
       - name: Send Notification
         if: failure() || cancelled()
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         with:
           payload: |
             {


### PR DESCRIPTION
Pin all third-party GitHub Actions to commit SHAs. Version comments are preserved for readability and Dependabot compatibility.