### PR TITLE
ci: update GitHub Actions to Node 24 before June 2 deadline

### DIFF
--- a/.github/workflows/run-crasher.yml
+++ b/.github/workflows/run-crasher.yml
@@ -84,10 +84,10 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       # checkout crasher
       - name: Checkout Crasher
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       # checkout qdrant dev
       - name: Checkout Qdrant
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: qdrant/qdrant
           ref: ${{ steps.default_inputs.outputs.qdrant_version }}
@@ -119,7 +119,7 @@ jobs:
 
           ./crash-things.sh qdrant ../qdrant-src/target/debug/qdrant "$crash_probability" "$crashing_time" "$points_count" "$backup_storage_dir"
       - name: Upload logs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: logs
@@ -137,7 +137,7 @@ jobs:
             tar --sparse -cf qdrant-workdir.tar qdrant/config qdrant/storage
           fi
       - name: Upload Qdrant workdir on failure
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure() || cancelled()
         with:
           name: qdrant-workdir


### PR DESCRIPTION
## Summary

GitHub will force all JavaScript-based actions to run on Node 24 starting **June 2, 2026**.
Node 20 will be removed from runners entirely on September 16, 2026.

This PR updates all `actions/*` references to the latest Node 24-native versions.

## Changes

| Action | From | To | Node |
|--------|------|----|------|
| actions/checkout | v1-v4 | v6.0.2 | 24 |
| actions/setup-python | v2-v5 | v6.2.0 | 24 |
| actions/setup-node | v2-v4 | v6.4.0 | 24 |
| actions/setup-go | v4-v5 | v6.4.0 | 24 |
| actions/cache | v3-v4 | v5.0.5 | 24 |
| actions/upload-artifact | v4 | v7.0.1 | 24 |
| actions/download-artifact | v4-v5 | v8.0.1 | 24 |

All target SHAs verified against their tags via the GitHub API.
All target versions confirmed running Node 24 in their action.yml.

## References

- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/