### PR TITLE
ci: update third-party actions to node 24

### DIFF
--- a/.github/workflows/run-crasher.yml
+++ b/.github/workflows/run-crasher.yml
@@ -147,6 +147,8 @@ jobs:
         if: failure() || cancelled()
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
+          webhook: ${{ secrets.CRASHER_CHANNEL_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "Crasher run status: ${{ job.status }}",
@@ -160,6 +162,3 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.CRASHER_CHANNEL_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/run-crasher.yml
+++ b/.github/workflows/run-crasher.yml
@@ -93,7 +93,7 @@ jobs:
           ref: ${{ steps.default_inputs.outputs.qdrant_version }}
           path: ./qdrant-src
       - name: Cache deps
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: |
             /home/runner/work/crasher/crasher
@@ -145,7 +145,7 @@ jobs:
           path: qdrant-workdir.tar
       - name: Send Notification
         if: failure() || cancelled()
-        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           payload: |
             {


### PR DESCRIPTION
Update all third-party GitHub Actions to Node 24-compatible versions before the June 2 deadline.