### PR TITLE
ci: replace arduino/setup-protoc (node20) with apt-get install

### DIFF
--- a/.github/workflows/run-crasher.yml
+++ b/.github/workflows/run-crasher.yml
@@ -79,7 +79,11 @@ jobs:
           fi
         shell: bash
       - name: Install Protoc
-        run: sudo apt-get install -y protobuf-compiler
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       # checkout crasher
       - name: Checkout Crasher
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/run-crasher.yml
+++ b/.github/workflows/run-crasher.yml
@@ -79,9 +79,7 @@ jobs:
           fi
         shell: bash
       - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        run: sudo apt-get install -y protobuf-compiler
       # checkout crasher
       - name: Checkout Crasher
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
- `arduino/setup-protoc` v3.0.0 is the latest release and still runs on Node.js 20, with no node24 update (arduino/setup-protoc#112)
- GitHub will force node24 on June 2, 2026
- Replace with `sudo apt-get install -y protobuf-compiler` which has no JS runtime dependency